### PR TITLE
Fixing an issue where if the device is in an uninitialized state, tha…

### DIFF
--- a/feeder/feeder.ino
+++ b/feeder/feeder.ino
@@ -208,6 +208,8 @@ void setup() {
 
   if(clientName == "" || clientName.length() > 32) {
     clientName = "ESP8266 AP";
+    ssid="";
+    password="";
   }
 
   WiFi.mode(WIFI_STA);
@@ -224,7 +226,7 @@ void loop() {
   if(state == 0 && (ssid != "" || ssid != NULL) && (password != "" || password != NULL)) {
     accessWifi();
     Serial.println(" LINE 200  ");
-  } else if(WiFi.status() != WL_CONNECTED) {
+  } else if(WiFi.status() != WL_CONNECTED && (WiFi.getMode() & WIFI_AP) == 0) {
     Serial.println( " LINE 204  ");
     setUpAccessPoint();
   }


### PR DESCRIPTION
…t the ssid and password default to empty and the device doesn't try to setup the access point over and over.